### PR TITLE
先行受付 に対応

### DIFF
--- a/synchroshift/contact_form.html
+++ b/synchroshift/contact_form.html
@@ -784,7 +784,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                             <li><a href="contact_form.html">お問い合わせ</a></li>
                         </ul>
                     </nav>
-                    <p class="h_contact"><a href="entry_form.html">無料で試す</a></p>
+                    <p class="h_contact"><a href="pre_entry_form.html">先行受付</a></p>
                 </div>
             </div>
         </div>
@@ -810,14 +810,14 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                         <li><a href="index.html#a10"><span class="font2">07.</span>料金プラン</a></li>
                         <li><a href="request_form.html"><span class="font2">08.</span>資料請求</a></li>
                         <li><a href="contact_form.html"><span class="font2">09.</span>お問い合わせ</a></li>
-                        <li><a href="entry_form.html"><span class="font2">10.</span>無料で試す</a></li>
+                        <li><a href="pre_entry_form.html"><span class="font2">10.</span>先行受付</a></li>
 					</ul>
 				</div>
 			</div>
 		</div>
 	</div>
-    
-    
+
+
     <section id="a11" class="padding130 form_mt bg_blue2">
         <div class="container960">
             <p class="eng_midashi font2 white"><span>CONTACT</span></p>
@@ -1028,7 +1028,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             </div>
         </div>
     </section>
-    
+
     <footer class="cy_footer">
         <div class="container1280">
             <div class="f_flex">
@@ -1047,7 +1047,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <p class="copy">© SynCube Co., Ltd.</p>
         </div>
     </footer>
-    
+
 <script src="js/spmenu.js?ver1.3"></script>
 <script type="text/javascript" src="js/jsmin.js"></script>
 

--- a/synchroshift/contact_thanks.html
+++ b/synchroshift/contact_thanks.html
@@ -43,7 +43,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                             <li><a href="contact_form.html">お問い合わせ</a></li>
                         </ul>
                     </nav>
-                    <p class="h_contact"><a href="entry_form.html">無料で試す</a></p>
+                    <p class="h_contact"><a href="pre_entry_form.html">先行受付</a></p>
                 </div>
             </div>
         </div>
@@ -69,15 +69,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                         <li><a href="index.html#a10"><span class="font2">07.</span>料金プラン</a></li>
                         <li><a href="request_form.html"><span class="font2">08.</span>資料請求</a></li>
                         <li><a href="contact_form.html"><span class="font2">09.</span>お問い合わせ</a></li>
-                        <li><a href="entry_form.html"><span class="font2">10.</span>無料で試す</a></li>
+                        <li><a href="pre_entry_form.html"><span class="font2">10.</span>先行受付</a></li>
 					</ul>
 				</div>
 			</div>
 		</div>
 	</div>
-    
-    
-    
+
+
+
     <section id="a11" class="padding130 form_mt bg_blue2">
         <div class="container960 thanks_box">
             <div class="thanks_img"><img src="images/thanks.png" width="428" height="428" alt=""></div>
@@ -86,8 +86,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         </div>
     </section>
 
-            
-    
+
+
     <footer class="cy_footer">
         <div class="container1280">
             <div class="f_flex">
@@ -106,7 +106,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <p class="copy">© SynCube Co., Ltd.</p>
         </div>
     </footer>
-    
+
 <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
 <script src="js/spmenu.js?ver1.3"></script>
 <script type="text/javascript" src="js/jsmin.js"></script>

--- a/synchroshift/css/index.css
+++ b/synchroshift/css/index.css
@@ -1298,7 +1298,7 @@ header.DownMove {
 }
 
 .free_box h3 {
-  font-size: 45px;
+  font-size: 38px;
   font-weight: bold;
 }
 
@@ -1522,7 +1522,7 @@ header.DownMove {
 .plan_p3 {
   text-align: center;
   line-height: 1.3em;
-  font-size: 40px;
+  font-size: 32px;
   margin-top: 20px;
   font-weight: bold;
 }
@@ -3875,7 +3875,7 @@ input[type="file"]::-webkit-file-upload-button {
   }
   .plan_p3 {
     line-height: 1.5em;
-    font-size: 20px;
+    font-size: 18px;
     margin-top: 15px;
   }
   /*

--- a/synchroshift/index.html
+++ b/synchroshift/index.html
@@ -357,7 +357,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </section>
 
 
-    <section id="a9" class="padding140 bg_blue">
+    <!-- <section id="a9" class="padding140 bg_blue">
         <div class="container1360">
             <p class="eng_midashi font2 z500"><span>FLOW</span></p>
             <h2 class="img_midashi font_b mt-25 spmt-20 z500">ご利用の流れ</h2>
@@ -365,7 +365,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
             <div class="center max_img100 mt-50 spmt-30"><img src="images/top_flow.png" width="1244" height="1393" alt=""></div>
         </div>
-    </section>
+    </section> -->
 
     <section id="a10" class="padding140 container1280">
         <p class="eng_midashi font2 z500"><span>PLAN</span></p>

--- a/synchroshift/index.html
+++ b/synchroshift/index.html
@@ -45,7 +45,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                             <li><a href="contact_form.html">お問い合わせ</a></li>
                         </ul>
                     </nav>
-                    <p class="h_contact"><a href="entry_form.html">無料で試す</a></p>
+                    <p class="h_contact"><a href="pre_entry_form.html">先行受付</a></p>
                 </div>
             </div>
         </div>
@@ -71,13 +71,13 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                         <li><a href="#a10"><span class="font2">07.</span>料金プラン</a></li>
                         <li><a href="request_form.html"><span class="font2">08.</span>資料請求</a></li>
                         <li><a href="contact_form.html"><span class="font2">09.</span>お問い合わせ</a></li>
-                        <li><a href="entry_form.html"><span class="font2">10.</span>無料で試す</a></li>
+                        <li><a href="pre_entry_form.html"><span class="font2">10.</span>先行受付</a></li>
 					</ul>
 				</div>
 			</div>
 		</div>
 	</div>
-    
+
     <section class="top_main">
         <div class="main_flex">
             <div class="main_left">
@@ -90,21 +90,21 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                         <div><img src="images/top5.png" width="188" height="188" alt=""></div>
                         <div><img src="images/top6.png" width="188" height="188" alt=""></div>
                     </div>
-                    <p class="main_more brnone740"><a href="entry_form.html">無料で試す<img src="images/shape1.png" width="12" height="18" alt=""></a></p>
+                    <p class="main_more brnone740"><a href="pre_entry_form.html">先行受付<img src="images/shape1.png" width="12" height="18" alt=""></a></p>
                 </div>
             </div>
             <div class="main_right"><img src="images/top7_2.png" width="841" height="496" alt=""></div>
-            <p class="main_more br740"><a href="entry_form.html">無料で試す<img src="images/shape1.png" width="12" height="18" alt=""></a></p>
+            <p class="main_more br740"><a href="pre_entry_form.html">先行受付<img src="images/shape1.png" width="12" height="18" alt=""></a></p>
         </div>
     </section>
-    
+
     <section id="a1" class="pt-140 container1360">
         <p class="eng_midashi font2"><span>SITUATION</span></p>
         <div class="posi mt-25 spmt-20">
             <h2 class="img_midashi font_b midashi_padding">こんなお悩みは<img src="images/top8.png" width="328" height="51" alt="">が解決します！</h2>
             <div class="robo_img"><img src="images/top9.png" width="148" height="176" alt=""></div>
         </div>
-        
+
         <div class="mt-80 spmt-40">
             <ul class="tab tab_list">
                 <li><a href="#page-1"><img src="images/top10.png" width="300" height="354" alt=""></a></li>
@@ -126,7 +126,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <section id="a2" class="pt-110 pb-160 container1280">
         <p class="eng_midashi font2"><span>HOW TO USE</span></p>
         <h2 class="img_midashi font_b mt-25 spmt-20">簡単！<img src="images/top8.png" width="362" height="59" alt="">の使い方</h2>
-        
+
         <h3 class="mt-110 spmt-40 font_b"><span class="shape_midashi">スタッフ例</span></h3>
         <div class="use_list mt-80 spmt-30">
             <div>
@@ -147,7 +147,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 出勤日や同じ日に出勤するメンバーを<br class="brnone1580"><br class="br740">確認できます！</p>
             </div>
         </div>
-        
+
         <h3 class="mt-110 spmt-40 font_b"><span class="shape_midashi style_green">シフト管理者側</span></h3>
         <div class="use_list mt-80 spmt-30">
             <div>
@@ -171,7 +171,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             </div>
         </div>
     </section>
-    
+
     <section id="a3" class="padding140 bg_dot_gray">
         <div class="container1280">
             <p class="eng_midashi font2"><span>POINT</span></p>
@@ -186,13 +186,13 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <div class="img100"><img src="images/top23.png" width="460" height="363" alt=""></div>
         </div>
     </section>
-    
+
     <!--
     <section id="a4" class="pt-140 pb-150 container1280">
         <p class="eng_midashi font2"><span>FEATURES</span></p>
         <h2 class="img_midashi font_b mt-25 spmt-20"><img src="images/top8.png" width="362" height="59" alt="">の機能</h2>
         <p class="ta-c text30 mt-40 spmt-30 letter008 t-hi22">希望休の集約からシフトの完成までの作業をSynchroshiftが代行！</p>
-        
+
         <div class="feature_flex mt-120 spmt-40">
             <div class="feature_left">
                 <h3 class="num_midashi font_b color_green"><span class="font2">1</span>希望休の申請</h3>
@@ -204,7 +204,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             </div>
             <div class="feature_right img_shadow img100"><img src="images/top24.png" width="639" height="414" alt=""></div>
         </div>
-        
+
         <div class="feature_flex mt-140 spmt-50">
             <div class="feature_left">
                 <h3 class="num_midashi font_b color_green"><span class="font2">2</span>希望休の集計</h3>
@@ -215,7 +215,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             </div>
             <div class="feature_right img_shadow img100"><img src="images/top25.png" width="639" height="414" alt=""></div>
         </div>
-        
+
         <div class="feature_flex mt-140 spmt-50">
             <div class="feature_left">
                 <h3 class="num_midashi font_b color_green"><span class="font2">3</span>シフト作成</h3>
@@ -226,7 +226,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             </div>
             <div class="feature_right img_shadow img100"><img src="images/top26.png" width="639" height="414" alt=""></div>
         </div>
-        
+
         <div class="feature_flex mt-140 spmt-50">
             <div class="feature_left">
                 <h3 class="num_midashi font_b color_green"><span class="font2">4</span>シフト共有</h3>
@@ -240,7 +240,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         </div>
     </section>
     -->
-    
+
     <section id="a5" class="padding140 bg_pink">
         <div class="container1280">
             <p class="eng_midashi font2"><span>MERIT</span></p>
@@ -277,10 +277,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                     </div>
                 </div>
             </div>
-        </div>        
+        </div>
     </section>
-    
-    
+
+
     <section id="a6" class="pt-160 pb-130">
         <div class="container1280">
             <p class="eng_midashi font2 z500"><span>FLOW</span></p>
@@ -294,7 +294,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <div class="center max_img100 mt-50 spmt-30"><img src="images/top32_2.png" width="1262" height="370" alt=""></div>
         </div>
     </section>
-    
+
     <!--
     <section id="a7" class="padding140 bg_gray">
         <div class="container1280">
@@ -349,36 +349,37 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <section id="a8" class="free_bg overflow_hidden">
         <div class="container1240 posi">
             <div class="free_box">
-                <h3 class="font_b z500">無料体験で<br class="br740">お試しください！</h3>
-                <p class="free_more mt-30 spmt-30 z500"><a href="entry_form.html">無料で試す<img src="images/shape3.png" width="13" height="21" alt=""></a></p>
+                <h3 class="font_b z500">まずは先行受付に<br class="br740">お申込みください！</h3>
+                <p class="free_more mt-30 spmt-30 z500"><a href="pre_entry_form.html">先行受付<img src="images/shape3.png" width="13" height="21" alt=""></a></p>
             </div>
             <div class="robo_img2"><img src="images/top35.png" width="397" height="349" alt=""></div>
         </div>
     </section>
-    
+
 
     <section id="a9" class="padding140 bg_blue">
         <div class="container1360">
             <p class="eng_midashi font2 z500"><span>FLOW</span></p>
             <h2 class="img_midashi font_b mt-25 spmt-20 z500">ご利用の流れ</h2>
-            
+            <p class="ta-c text22 mt-10 letter008 t-hi22">※サービス正式リリース後の流れになります</p>
+
             <div class="center max_img100 mt-50 spmt-30"><img src="images/top_flow.png" width="1244" height="1393" alt=""></div>
         </div>
     </section>
-    
+
     <section id="a10" class="padding140 container1280">
         <p class="eng_midashi font2 z500"><span>PLAN</span></p>
         <h2 class="img_midashi font_b mt-25 spmt-20 z500">ご利用プラン</h2>
-        
+
         <!--
         <p class="plan_p1 font_b mt-50 spmt-30">スタンダードプラン</p>
         <p class="plan_p2"><span class="span_bb">最大<span class="font_b"><span class="span_big">3</span>カ月間無料！</span></span></p>
         <p class="plan_p2 pt-10"><span class="span_bb">2022年<span class="font_b"><span class="span_big">秋</span>頃<br class="br740">リリース予定</span></span></p>
 -->
-        <p class="plan_p3">まずは無料でお試しください！</p>
-        <p class="free_more mt-60 spmt-40 z500"><a href="entry_form.html">無料で試す<img src="images/shape3.png" width="13" height="21" alt=""></a></p>
+        <p class="plan_p3">まずは先行受付にお申込みください！</p>
+        <p class="free_more mt-60 spmt-40 z500"><a href="pre_entry_form.html">先行受付<img src="images/shape3.png" width="13" height="21" alt=""></a></p>
 
-        
+
         <div class="mt-80 spmt-40">
             <div class="posi">
                 <table class="plan_table">
@@ -438,7 +439,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 </table>
             </div>
         </div>
-        
+
         <h3 class="mt-120 plan_midashi"><span class="span_bb">お支払い方法は<br class="br740">下記の<span class="big70 font_b">2</span>パターン</span></h3>
         <div class="plan_img_list mt-50 spmt-30">
             <div class="max_img100"><img src="images/top38.png" width="600" height="480" alt=""></div>
@@ -446,7 +447,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         </div>
         <p class="t-14 spt-12 ta-r spta-r mt-20 spmt-20">※詳しくは資料請求にてご確認ください。</p>
     </section>
-    
+
     <section id="a11" class="padding140 bg_blue2">
         <div class="container1280">
             <p class="eng_midashi font2 white"><span>CONTACT</span></p>
@@ -456,7 +457,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <p class="to_contact mt-50 spmt-30 z500"><a href="contact_form.html">お問い合わせ<img src="images/shape3.png" width="13" height="21" alt=""></a></p>
         </div>
     </section>
-    
+
     <footer class="cy_footer">
         <div class="container1280">
             <div class="f_flex">
@@ -475,7 +476,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <p class="copy">© SynCube Co., Ltd.</p>
         </div>
     </footer>
-    
+
 <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.2/jquery.min.js"></script>
 <script src="js/imgchange.js"></script>
 <script src="js/spmenu.js?ver1.3"></script>

--- a/synchroshift/pre_entry_form.html
+++ b/synchroshift/pre_entry_form.html
@@ -502,6 +502,7 @@
               value="https&#x3a;&#x2f;&#x2f;synchroseries.jp&#x2f;synchroshift&#x2f;contact_thanks.html"
             />
             <input type="hidden" name="Subject" value="先行受付" />
+            <input type="hidden" name="Classification" value="先行受付" />
             <div class="contact_form">
               <div>
                 <p class="c_cell1">姓<span class="hissu">必須</span></p>

--- a/synchroshift/pre_entry_form.html
+++ b/synchroshift/pre_entry_form.html
@@ -1,0 +1,724 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <!-- Google Tag Manager -->
+    <script>
+      (function (w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != "dataLayer" ? "&l=" + l : "";
+        j.async = true;
+        j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
+        f.parentNode.insertBefore(j, f);
+      })(window, document, "script", "dataLayer", "GTM-NFDBPFF");
+    </script>
+    <!-- End Google Tag Manager -->
+    <meta charset="UTF-8" />
+    <title>お問い合わせ | シンクロシフト</title>
+    <meta name="description" content="" />
+    <meta name="keywords" content="" />
+    <meta
+      name="viewport"
+      content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no"
+    />
+    <meta name="format-detection" content="telephone=no" />
+    <link rel="stylesheet" type="text/css" href="css/reset.css" />
+    <link rel="stylesheet" href="css/index.css?ver1.11" type="text/css" />
+    <link rel="stylesheet" href="scss/index.scss" type="text/css" />
+    <link rel="stylesheet" href="css/cssmin.css" type="text/css" />
+    <link href="css/spmenu.css" rel="stylesheet" type="text/css" />
+    <script src="https://d17nz991552y2g.cloudfront.net/app/js/jqueryandencoder.ffa5afd5124fbedceea9.js"></script>
+    <script>
+      function trimBoth(str) {
+        return jQuery.trim(str);
+      }
+      function setAllDependancyFieldsMapping() {
+        var mapDependancyLabels = getMapDependenySelectValues(
+          jQuery("[id='property(module)']").val(),
+          "JSON_MAP_DEP_LABELS"
+        );
+        if (mapDependancyLabels) {
+          for (var i = 0; i < mapDependancyLabels.length; i++) {
+            var label = mapDependancyLabels[i];
+            var obj = document.forms["zsWebToCase_723432000004744485"][label];
+            if (obj) {
+              setDependent(obj, true);
+            }
+          }
+        }
+      }
+      function getMapDependenySelectValues(module, key) {
+        var dependencyObj = jQuery.parseJSON(
+          jQuery("[id='dependent_field_values_" + module + "']").val()
+        );
+        if (dependencyObj == undefined) {
+          return dependencyObj;
+        }
+        return dependencyObj[key];
+      }
+      function setDependent(obj, isload) {
+        var name = obj.id || (obj[0] && obj[0].id) || "";
+        var module = jQuery("[id='property(module)']").val();
+        var val = "";
+        var myObject = getMapDependenySelectValues(module, "JSON_VALUES");
+        if (myObject != undefined) {
+          val = myObject[name];
+        }
+        var mySelObject = getMapDependenySelectValues(
+          module,
+          "JSON_SELECT_VALUES"
+        );
+        if (val != null && val != "" && val != "null" && mySelObject) {
+          var fields = val;
+          for (var i in fields) {
+            if (fields.hasOwnProperty(i)) {
+              var isDependent = false;
+              var label = i;
+              var values = fields[i];
+              if (label.indexOf(")") > -1) {
+                label = label.replace(/\)/g, "_____");
+              }
+              if (label.indexOf("(") > -1) {
+                label = label.replace(/\(/g, "____");
+              }
+              if (label.indexOf(".") > -1) {
+                label = label.replace(/\./g, "___");
+              }
+              var depObj =
+                document.forms["zsWebToCase_723432000004744485"][label];
+              if (depObj && depObj.options) {
+                var mapValues = "";
+                var selected_val = depObj.value;
+                var depLen = depObj.options.length - 1;
+                for (var n = depLen; n >= 0; n--) {
+                  if (depObj.options[n].selected) {
+                    if (mapValues == "") {
+                      mapValues = depObj.options[n].value;
+                    } else {
+                      mapValues = mapValues + ";;;" + depObj.options[n].value;
+                    }
+                  }
+                }
+                depObj.value = "";
+                var selectValues = mySelObject[label];
+                for (var k in values) {
+                  var rat = k;
+                  if (rat == "-None-") {
+                    rat = "";
+                  }
+                  var parentValues = mySelObject[name];
+                  if (rat == trimBoth(obj.value)) {
+                    isDependent = true;
+                    depObj.length = 0;
+                    var depvalues = values[k];
+                    var depLen = depvalues.length - 1;
+                    for (var j = 0; j <= depLen; j++) {
+                      var optionElement = document.createElement("OPTION");
+                      var displayValue = depvalues[j];
+                      var actualValue = displayValue;
+                      if (actualValue == "-None-") {
+                        optionElement.value = "";
+                        displayValue = "-None-";
+                      } else {
+                        optionElement.value = actualValue;
+                      }
+                      optionElement.text = displayValue;
+                      if (mapValues != undefined) {
+                        var mapValue = mapValues.split(";;;");
+                        var len = mapValue.length;
+                        for (var p = 0; p < len; p++) {
+                          if (actualValue == mapValue[p]) {
+                            optionElement.selected = true;
+                          }
+                        }
+                      }
+                      depObj.options.add(optionElement);
+                    }
+                  }
+                }
+                if (!isDependent) {
+                  depObj.length = 0;
+                  var len = selectValues.length;
+                  for (var j = 0; j < len; j++) {
+                    var actualValue = selectValues[j];
+                    var optionElement = document.createElement("OPTION");
+                    if (actualValue == "-None-") {
+                      optionElement.value = "";
+                    } else {
+                      optionElement.value = selectValues[j];
+                    }
+                    optionElement.text = selectValues[j];
+                    depObj.options.add(optionElement);
+                  }
+                  depObj.value = selected_val;
+                }
+                if (!isload) {
+                  setDependent(depObj, false);
+                }
+                var jdepObj = jQuery(depObj);
+                if (jdepObj.hasClass("select2-offscreen")) {
+                  jdepObj.select2("val", jdepObj.val());
+                }
+              }
+            }
+          }
+        }
+      }
+      function setSelectAll(id) {
+        var parentElement = document.getElementById(id);
+        var hiddenInput = parentElement.querySelector("#hiddenoptions");
+        var selectAllElement = parentElement.querySelector("#selectall" + id);
+        var selectedValues = [];
+        var checkboxes = parentElement.querySelectorAll(".wb_multi_pick_input");
+        checkboxes.forEach(function (cb) {
+          cb.checked = selectAllElement.checked;
+          if (cb.checked && cb.value) {
+            selectedValues.push(cb.value);
+          }
+        });
+        hiddenInput.value = selectedValues.join(",");
+      }
+      function setMultiSelectOption(id, obj) {
+        var parentElement = document.getElementById(id);
+        var hiddenInput = parentElement.querySelector("#hiddenoptions");
+        var selectAllElement = parentElement.querySelector("#selectall" + id);
+        var selectedStr = hiddenInput.value;
+        var selectedValues = selectedStr ? selectedStr.split(",") : [];
+        if (obj.checked && obj.value) {
+          selectedValues.push(obj.value);
+        } else if (!obj.checked && obj.value) {
+          selectedValues.splice(selectedValues.indexOf(obj.value), 1);
+          selectAllElement.checked = false;
+        } else {
+          selectAllElement.checked = false;
+        }
+        hiddenInput.value = selectedValues.join(",");
+      }
+      var zctt = (function () {
+        var tt,
+          mw = 400,
+          top = 10,
+          left = 0,
+          doctt = document;
+        var ieb = doctt.all ? true : false;
+        return {
+          showtt: function (cont, wid) {
+            if (tt == null) {
+              tt = doctt.createElement("div");
+              tt.setAttribute("id", "tooltip-zc");
+              doctt.body.appendChild(tt);
+              doctt.onmousemove = this.setpos;
+              doctt.onclick = this.hidett;
+            }
+            tt.style.display = "block";
+            tt.innerHTML = cont;
+            tt.style.width = wid ? wid + "px" : "auto";
+            if (!wid && ieb) {
+              tt.style.width = tt.offsetWidth;
+            }
+            if (tt.offsetWidth > mw) {
+              tt.style.width = mw + "px";
+            }
+            h = parseInt(tt.offsetHeight) + top;
+            w = parseInt(tt.offsetWidth) + left;
+          },
+          hidett: function () {
+            tt.style.display = "none";
+          },
+          setpos: function (e) {
+            var u = ieb ? event.clientY + doctt.body.scrollTop : e.pageY;
+            var l = ieb ? event.clientX + doctt.body.scrollLeft : e.pageX;
+            var cw = doctt.body.clientWidth;
+            var ch = doctt.body.clientHeight;
+            if (l < 0) {
+              tt.style.left = left + "px";
+              tt.style.right = "";
+            } else if (l + w + left > cw) {
+              tt.style.left = "";
+              tt.style.right = cw - l + left + "px";
+            } else {
+              tt.style.right = "";
+              tt.style.left = l + left + "px";
+            }
+            if (u < 0) {
+              tt.style.top = top + "px";
+              tt.style.bottom = "";
+            } else if (u + h + left > ch) {
+              tt.style.top = "";
+              tt.style.bottom = ch - u + top + "px";
+            } else {
+              tt.style.bottom = "";
+              tt.style.top = u + top + "px";
+            }
+          },
+        };
+      })();
+      var zsWebFormMandatoryFields = new Array(
+        "Contact Name",
+        "First Name",
+        "Email",
+        "Phone",
+        "所属組織",
+        "役職",
+        "事業所数",
+        "サービス種別",
+        "従業員数"
+      );
+      var zsFieldsDisplayLabelArray = new Array(
+        "姓",
+        "名",
+        "メールアドレス",
+        "電話",
+        "所属組織",
+        "役職",
+        "事業所数",
+        "サービス種別",
+        "従業員数"
+      );
+      function zsValidateMandatoryFields() {
+        var name = "";
+        var email = "";
+        var isError = 0;
+        for (var index = 0; index < zsWebFormMandatoryFields.length; index++) {
+          isError = 0;
+          var fieldObject =
+            document.forms["zsWebToCase_723432000004744485"][
+              zsWebFormMandatoryFields[index]
+            ];
+          if (fieldObject) {
+            if (fieldObject.value.replace(/^\s+|\s+$/g, "").length == 0) {
+              alert(zsFieldsDisplayLabelArray[index] + " は入力必須です ");
+              fieldObject.focus();
+              isError = 1;
+              return false;
+            } else {
+              if (fieldObject.name == "Email") {
+                if (
+                  !fieldObject.value.match(
+                    /^([\w_][\w\-_.+\'&]*)@(?=.{4,256}$)(([\w]+)([\-_]*[\w])*[\.])+[a-zA-Z]{2,22}$/
+                  )
+                ) {
+                  isError = 1;
+                  alert("有効なメールアドレスを入力してください");
+                  fieldObject.focus();
+                  return false;
+                }
+              }
+            }
+            if (fieldObject.nodeName == "SELECT") {
+              if (
+                fieldObject.options[fieldObject.selectedIndex].value == "-None-"
+              ) {
+                alert(zsFieldsDisplayLabelArray[index] + " を入力してください");
+                fieldObject.focus();
+                isError = 1;
+                return false;
+              }
+            }
+            if (fieldObject.type == "checkbox") {
+              if (fieldObject.checked == false) {
+                alert("承認をお願いします " + zsFieldsDisplayLabelArray[index]);
+                fieldObject.focus();
+                isError = 1;
+                return false;
+              }
+            }
+          }
+        }
+        if (isError == 0) {
+          document
+            .getElementById("zsSubmitButton_723432000004744485")
+            .setAttribute("disabled", "disabled");
+        }
+      }
+      document.addEventListener("readystatechange", function () {
+        if (document.readyState === "complete" && window.zsRegenerateCaptcha) {
+          zsRegenerateCaptcha();
+        }
+        setAllDependancyFieldsMapping();
+        document
+          .getElementById("zsSubmitButton_723432000004744485")
+          .removeAttribute("disabled");
+      });
+      function zsResetWebForm(webFormId) {
+        document.forms["zsWebToCase_" + webFormId].reset();
+        document
+          .getElementById("zsSubmitButton_723432000004744485")
+          .removeAttribute("disabled");
+        setAllDependancyFieldsMapping();
+      }
+    </script>
+  </head>
+  <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript
+      ><iframe
+        src="https://www.googletagmanager.com/ns.html?id=GTM-NFDBPFF"
+        height="0"
+        width="0"
+        style="display: none; visibility: hidden"
+      ></iframe
+    ></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+    <header class="cy_header">
+      <div class="header_bg">
+        <div class="h_flex">
+          <h1 class="logo">
+            <a href="index.html"
+              ><img
+                src="images/top1.png"
+                width="225"
+                height="56"
+                alt="お問い合わせ | シンクロシフト"
+            /></a>
+          </h1>
+          <div class="h_right">
+            <nav class="cy_nav nav_sc">
+              <ul>
+                <li><a href="index.html#a1">サービス紹介</a></li>
+                <li><a href="index.html#a2">使い方</a></li>
+                <li><a href="index.html#a3">機能</a></li>
+                <li><a href="index.html#a5">メリット</a></li>
+                <li><a href="index.html#a9">ご利用の流れ</a></li>
+                <!--<li><a href="index.html#a7">導入事例</a></li>-->
+                <li><a href="index.html#a10">料金プラン</a></li>
+                <li><a href="request_form.html">資料請求</a></li>
+                <li><a href="contact_form.html">お問い合わせ</a></li>
+              </ul>
+            </nav>
+            <p class="h_contact"><a href="pre_entry_form.html">先行受付</a></p>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <div id="sp_box">
+      <div id="spicon" class="font2">
+        <span></span>
+        <span></span>
+        <span></span>
+        <p id="close" class="font1"></p>
+      </div>
+      <div id="open_menu">
+        <div id="center_box">
+          <div class="m_width z500">
+            <ul class="page_link nav_sc">
+              <li>
+                <a href="index.html"
+                  ><span class="font2">01.</span>トップページ</a
+                >
+              </li>
+              <li>
+                <a href="index.html#a1"
+                  ><span class="font2">02.</span>サービス紹介</a
+                >
+              </li>
+              <li>
+                <a href="index.html#a2"><span class="font2">03.</span>使い方</a>
+              </li>
+              <li>
+                <a href="index.html#a3"><span class="font2">04.</span>機能</a>
+              </li>
+              <li>
+                <a href="index.html#a5"
+                  ><span class="font2">05.</span>メリット</a
+                >
+              </li>
+              <li>
+                <a href="index.html#a9"
+                  ><span class="font2">06.</span>ご利用の流れ</a
+                >
+              </li>
+              <li>
+                <a href="index.html#a10"
+                  ><span class="font2">07.</span>料金プラン</a
+                >
+              </li>
+              <li>
+                <a href="request_form.html"
+                  ><span class="font2">08.</span>資料請求</a
+                >
+              </li>
+              <li>
+                <a href="contact_form.html"
+                  ><span class="font2">09.</span>お問い合わせ</a
+                >
+              </li>
+              <li>
+                <a href="pre_entry_form.html"
+                  ><span class="font2">10.</span>先行受付</a
+                >
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <section id="a11" class="padding130 form_mt bg_blue2">
+      <div class="container960">
+        <p class="eng_midashi font2 white"><span>Pre Entry</span></p>
+        <h2 class="img_midashi font_b mt-25 spmt-20 white">先行受付</h2>
+        <p class="ta-c text22 mt-40 spmt-30 letter008 t-hi22 white">
+          フォームに必要事項をご記入ください。<br />
+          対象となる方には、先行でご利用いただけるようにご案内いたします。
+        </p>
+
+        <div
+          id="zohoSupportWebToCase"
+          class="contact_box zsFormClass mt-50 spmt-30"
+        >
+          <form
+            name="zsWebToCase_723432000004744485"
+            id="zsWebToCase_723432000004744485"
+            action="https://support.synchroshift.jp/support/WebToCase"
+            method="POST"
+            onSubmit="return zsValidateMandatoryFields()"
+            enctype="multipart/form-data"
+          >
+            <input
+              type="hidden"
+              name="xnQsjsdp"
+              value="edbsnfed1c9939f506cda58cd14b4469d779d"
+            />
+            <input
+              type="hidden"
+              name="xmIwtLD"
+              value="edbsn3cc11b6e737555e01159b5906453206f44672f104f7e24d100d5185865163605"
+            />
+            <input type="hidden" name="xJdfEaS" value="" />
+            <input type="hidden" name="actionType" value="Q2FzZXM=" />
+            <input type="hidden" id="property(module)" value="Cases" />
+            <input
+              type="hidden"
+              id="dependent_field_values_Cases"
+              value='&#x7b;"JSON_VALUES"&#x3a;&#x7b;&#x7d;,"JSON_SELECT_VALUES"&#x3a;&#x7b;&#x7d;,"JSON_MAP_DEP_LABELS"&#x3a;&#x5b;&#x5d;&#x7d;'
+            />
+            <input
+              type="hidden"
+              name="returnURL"
+              value="https&#x3a;&#x2f;&#x2f;synchroseries.jp&#x2f;synchroshift&#x2f;contact_thanks.html"
+            />
+            <input type="hidden" name="Subject" value="先行受付" />
+            <div class="contact_form">
+              <div>
+                <p class="c_cell1">姓<span class="hissu">必須</span></p>
+                <div class="c_cell2">
+                  <input
+                    type="text"
+                    maxlength="120"
+                    name="Contact Name"
+                    class="manfieldbdr size"
+                  />
+                </div>
+              </div>
+              <div>
+                <p class="c_cell1">名<span class="hissu">必須</span></p>
+                <div class="c_cell2">
+                  <input
+                    type="text"
+                    maxlength="120"
+                    name="First Name"
+                    value=""
+                    class="manfieldbdr size"
+                  />
+                </div>
+              </div>
+              <div>
+                <p class="c_cell1">
+                  メールアドレス<span class="hissu">必須</span>
+                </p>
+                <div class="c_cell2">
+                  <input
+                    type="text"
+                    maxlength="120"
+                    name="Email"
+                    value=""
+                    class="manfieldbdr size"
+                  />
+                </div>
+              </div>
+              <div>
+                <p class="c_cell1">電話<span class="hissu">必須</span></p>
+                <div class="c_cell2">
+                  <input
+                    type="text"
+                    maxlength="120"
+                    name="Phone"
+                    value=""
+                    class="manfieldbdr size"
+                  />
+                </div>
+              </div>
+              <div>
+                <p class="c_cell1">所属組織<span class="hissu">必須</span></p>
+                <div class="c_cell2">
+                  <input
+                    type="text"
+                    maxlength="120"
+                    name="所属組織"
+                    value=""
+                    class="manfieldbdr size"
+                  />
+                </div>
+              </div>
+              <div>
+                <p class="c_cell1">役職<span class="hissu">必須</span></p>
+                <div class="c_cell2">
+                  <input
+                    type="text"
+                    maxlength="120"
+                    name="役職"
+                    value=""
+                    class="manfieldbdr size"
+                  />
+                </div>
+              </div>
+              <div>
+                <p class="c_cell1">
+                  想定事業所数<span class="hissu">必須</span>
+                </p>
+                <div class="c_cell2">
+                  <select
+                    name="事業所数"
+                    value=""
+                    class="manfieldbdr size"
+                    onchange="setDependent(this, false)"
+                    id="CASECF3"
+                  >
+                    <option value="">--未選択--</option>
+                    <option value="1事業所">1事業所</option>
+                    <option value="2事業所">2事業所</option>
+                    <option value="3事業所">3事業所</option>
+                    <option value="4事業所">4事業所</option>
+                    <option value="5事業所">5事業所</option>
+                    <option value="6事業所以上">6事業所以上</option>
+                  </select>
+                </div>
+              </div>
+              <div>
+                <p class="c_cell1">
+                  想定サービス種別<span class="hissu">必須</span>
+                </p>
+                <div class="c_cell2">
+                  <select
+                    name="サービス種別"
+                    value=""
+                    class="manfieldbdr size"
+                    onchange="setDependent(this, false)"
+                    id="CASECF4"
+                  >
+                    <option value="">--未選択--</option>
+                    <option value="訪問看護">訪問看護</option>
+                    <option value="訪問介護">訪問介護</option>
+                    <option value="デイサービス">デイサービス</option>
+                    <option value="ショートステイ">ショートステイ</option>
+                    <option value="グループホーム">グループホーム</option>
+                    <option value="特養">特養</option>
+                    <option value="定期巡回ステーション">
+                      定期巡回ステーション
+                    </option>
+                    <option value="ヘルパーステーション">
+                      ヘルパーステーション
+                    </option>
+                    <option value="小規模多機能">小規模多機能</option>
+                    <option value="老健 (介護老人保健施設)">
+                      老健 (介護老人保健施設)
+                    </option>
+                  </select>
+                </div>
+              </div>
+              <div>
+                <p class="c_cell1">
+                  お問い合わせ内容<span class="hissu">必須</span>
+                </p>
+                <div class="c_cell2">
+                  <select
+                    name="従業員数"
+                    value=""
+                    class="manfieldbdr size"
+                    onchange="setDependent(this, false)"
+                    id="CASECF5"
+                  >
+                    <option value="10名以下">10名以下</option>
+                    <option value="11〜20名">11〜20名</option>
+                    <option value="21〜30名">21〜30名</option>
+                    <option value="31〜40名">31〜40名</option>
+                    <option value="41〜50名">41〜50名</option>
+                    <option value="51〜100名">51〜100名</option>
+                    <option value="101名以上">101名以上</option>
+                  </select>
+                </div>
+              </div>
+              <div>
+                <p class="c_cell1">お問い合わせ内容</p>
+                <div class="c_cell2">
+                  <textarea
+                    name="Description"
+                    maxlength="3000"
+                    width="250"
+                    height="250"
+                    class="area"
+                  ></textarea>
+                </div>
+              </div>
+            </div>
+            <div class="sub mt-60 spmt-40">
+              <div class="sub_width h_flex">
+                <input
+                  type="submit"
+                  id="zsSubmitButton_723432000000284037"
+                  class="zsFontClass"
+                  value="送信"
+                />
+                <img src="images/shape1.png" width="12" height="18" alt="" />
+              </div>
+            </div>
+          </form>
+          <div class="robo_img3">
+            <img src="images/top40.png" width="340" height="200" alt="" />
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <footer class="cy_footer">
+      <div class="container1280">
+        <div class="f_flex">
+          <div class="f_left">
+            <div class="f_logo">
+              <img src="images/top2.png" width="729" height="181" alt="" />
+            </div>
+            <p class="mt-30 spmt-20">
+              株式会社サインキューブ<br />
+              【本社】<br class="br740" />〒106-0045
+              <br class="br740" />東京都港区麻布十番2丁目20番7号
+            </p>
+          </div>
+          <ul class="f_nav">
+            <li>
+              <a href="https://hp.syncube.co.jp/company.html" target="_blank"
+                >会社概要</a
+              >
+            </li>
+            <li><a href="terms.html">利用規約</a></li>
+            <li>
+              <a
+                href="https://hp.syncube.co.jp/privacypolicy.html"
+                target="_blank"
+                >プライバシーポリシー</a
+              >
+            </li>
+            <li><a href="contact_form.html">お問い合わせ</a></li>
+          </ul>
+        </div>
+        <p class="copy">© SynCube Co., Ltd.</p>
+      </div>
+    </footer>
+
+    <script src="js/spmenu.js?ver1.3"></script>
+    <script type="text/javascript" src="js/jsmin.js"></script>
+  </body>
+</html>

--- a/synchroshift/pre_entry_thanks.html
+++ b/synchroshift/pre_entry_thanks.html
@@ -1,0 +1,197 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <!-- Google Tag Manager -->
+    <script>
+      (function (w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != "dataLayer" ? "&l=" + l : "";
+        j.async = true;
+        j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
+        f.parentNode.insertBefore(j, f);
+      })(window, document, "script", "dataLayer", "GTM-NFDBPFF");
+    </script>
+    <!-- End Google Tag Manager -->
+    <meta charset="UTF-8" />
+    <title>お問い合わせ完了 | シンクロシフト</title>
+    <meta name="description" content="" />
+    <meta name="keywords" content="" />
+    <meta
+      name="viewport"
+      content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no"
+    />
+    <meta name="format-detection" content="telephone=no" />
+    <link rel="stylesheet" type="text/css" href="css/reset.css" />
+    <link rel="stylesheet" href="css/index.css?ver1.11" type="text/css" />
+    <link rel="stylesheet" href="scss/index.scss" type="text/css" />
+    <link rel="stylesheet" href="css/cssmin.css" type="text/css" />
+    <link href="css/spmenu.css" rel="stylesheet" type="text/css" />
+  </head>
+  <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript
+      ><iframe
+        src="https://www.googletagmanager.com/ns.html?id=GTM-NFDBPFF"
+        height="0"
+        width="0"
+        style="display: none; visibility: hidden"
+      ></iframe
+    ></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+    <header class="cy_header">
+      <div class="header_bg">
+        <div class="h_flex">
+          <h1 class="logo">
+            <a href="index.html"
+              ><img
+                src="images/top1.png"
+                width="225"
+                height="56"
+                alt="お問い合わせ完了 | シンクロシフト"
+            /></a>
+          </h1>
+          <div class="h_right">
+            <nav class="cy_nav nav_sc">
+              <ul>
+                <li><a href="index.html#a1">サービス紹介</a></li>
+                <li><a href="index.html#a2">使い方</a></li>
+                <li><a href="index.html#a3">機能</a></li>
+                <li><a href="index.html#a5">メリット</a></li>
+                <li><a href="index.html#a9">ご利用の流れ</a></li>
+                <!--<li><a href="index.html#a7">導入事例</a></li>-->
+                <li><a href="index.html#a10">料金プラン</a></li>
+                <li><a href="request_form.html">資料請求</a></li>
+                <li><a href="contact_form.html">お問い合わせ</a></li>
+              </ul>
+            </nav>
+            <p class="h_contact"><a href="pre_entry_form.html">先行受付</a></p>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <div id="sp_box">
+      <div id="spicon" class="font2">
+        <span></span>
+        <span></span>
+        <span></span>
+        <p id="close" class="font1"></p>
+      </div>
+      <div id="open_menu">
+        <div id="center_box">
+          <div class="m_width z500">
+            <ul class="page_link nav_sc">
+              <li>
+                <a href="index.html"
+                  ><span class="font2">01.</span>トップページ</a
+                >
+              </li>
+              <li>
+                <a href="index.html#a1"
+                  ><span class="font2">02.</span>サービス紹介</a
+                >
+              </li>
+              <li>
+                <a href="index.html#a2"><span class="font2">03.</span>使い方</a>
+              </li>
+              <li>
+                <a href="index.html#a3"><span class="font2">04.</span>機能</a>
+              </li>
+              <li>
+                <a href="index.html#a5"
+                  ><span class="font2">05.</span>メリット</a
+                >
+              </li>
+              <li>
+                <a href="index.html#a9"
+                  ><span class="font2">06.</span>ご利用の流れ</a
+                >
+              </li>
+              <li>
+                <a href="index.html#a10"
+                  ><span class="font2">07.</span>料金プラン</a
+                >
+              </li>
+              <li>
+                <a href="request_form.html"
+                  ><span class="font2">08.</span>資料請求</a
+                >
+              </li>
+              <li>
+                <a href="contact_form.html"
+                  ><span class="font2">09.</span>お問い合わせ</a
+                >
+              </li>
+              <li>
+                <a href="pre_entry_form.html"
+                  ><span class="font2">10.</span>先行受付</a
+                >
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <section id="a11" class="padding130 form_mt bg_blue2">
+      <div class="container960 thanks_box">
+        <div class="thanks_img">
+          <img src="images/thanks.png" width="428" height="428" alt="" />
+        </div>
+        <p class="thanks_p">
+          事前受付への申し込み、<br class="br740" />ありがとうございました！
+        </p>
+        <p class="mt-30 spmt-20 thanks_p2">
+          対象となる方から先行でご利用いただけるようにご案内いたしますので、
+          <br />
+          今しばらくお待ちください。
+        </p>
+      </div>
+    </section>
+
+    <footer class="cy_footer">
+      <div class="container1280">
+        <div class="f_flex">
+          <div class="f_left">
+            <div class="f_logo">
+              <img src="images/top2.png" width="729" height="181" alt="" />
+            </div>
+            <p class="mt-30 spmt-20">
+              株式会社サインキューブ<br />
+              【本社】<br class="br740" />〒106-0045
+              <br class="br740" />東京都港区麻布十番2丁目20番7号
+            </p>
+          </div>
+          <ul class="f_nav">
+            <li>
+              <a href="https://hp.syncube.co.jp/company.html" target="_blank"
+                >会社概要</a
+              >
+            </li>
+            <li><a href="terms.html">利用規約</a></li>
+            <li>
+              <a
+                href="https://hp.syncube.co.jp/privacypolicy.html"
+                target="_blank"
+                >プライバシーポリシー</a
+              >
+            </li>
+            <li><a href="contact_form.html">お問い合わせ</a></li>
+          </ul>
+        </div>
+        <p class="copy">© SynCube Co., Ltd.</p>
+      </div>
+    </footer>
+
+    <script
+      type="text/javascript"
+      src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"
+    ></script>
+    <script src="js/spmenu.js?ver1.3"></script>
+    <script type="text/javascript" src="js/jsmin.js"></script>
+    <script type="text/javascript" src="custom.js"></script>
+  </body>
+</html>

--- a/synchroshift/privacypolicy.html
+++ b/synchroshift/privacypolicy.html
@@ -43,7 +43,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                             <li><a href="contact_form.html">お問い合わせ</a></li>
                         </ul>
                     </nav>
-                    <p class="h_contact"><a href="entry_form.html">無料で試す</a></p>
+                    <p class="h_contact"><a href="pre_entry_form.html">先行受付</a></p>
                 </div>
             </div>
         </div>
@@ -69,15 +69,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                         <li><a href="index.html#a10"><span class="font2">07.</span>料金プラン</a></li>
                         <li><a href="request_form.html"><span class="font2">08.</span>資料請求</a></li>
                         <li><a href="contact_form.html"><span class="font2">09.</span>お問い合わせ</a></li>
-                        <li><a href="entry_form.html"><span class="font2">10.</span>無料で試す</a></li>
+                        <li><a href="pre_entry_form.html"><span class="font2">10.</span>先行受付</a></li>
 					</ul>
 				</div>
 			</div>
 		</div>
 	</div>
-    
-    
-    
+
+
+
     <section id="a11" class="padding130 form_mt">
         <div class="container1280">
             <p class="eng_midashi font2"><span>PRIVACY POLIST</span></p>
@@ -222,13 +222,13 @@ Cookieを利用し、ログイン状態の保持に活用しています。当�
             <p class="mt-60 spmt-40">以上</p>
             <p class="mt-20 spmt-20">2022年4月1日制定</p>
 
-        
-        
+
+
         </div>
     </section>
 
-            
-    
+
+
     <footer class="cy_footer">
         <div class="container1280">
             <div class="f_flex">
@@ -247,7 +247,7 @@ Cookieを利用し、ログイン状態の保持に活用しています。当�
             <p class="copy">© SynCube Co., Ltd.</p>
         </div>
     </footer>
-    
+
 <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
 <script src="js/spmenu.js?ver1.3"></script>
 <script type="text/javascript" src="js/jsmin.js"></script>

--- a/synchroshift/request_form.html
+++ b/synchroshift/request_form.html
@@ -43,7 +43,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                             <li><a href="contact_form.html">お問い合わせ</a></li>
                         </ul>
                     </nav>
-                    <p class="h_contact"><a href="entry_form.html">無料で試す</a></p>
+                    <p class="h_contact"><a href="pre_entry_form.html">先行受付</a></p>
                 </div>
             </div>
         </div>
@@ -69,15 +69,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                         <li><a href="index.html#a10"><span class="font2">07.</span>料金プラン</a></li>
                         <li><a href="request_form.html"><span class="font2">08.</span>資料請求</a></li>
                         <li><a href="contact_form.html"><span class="font2">09.</span>お問い合わせ</a></li>
-                        <li><a href="entry_form.html"><span class="font2">10.</span>無料で試す</a></li>
+                        <li><a href="pre_entry_form.html"><span class="font2">10.</span>先行受付</a></li>
 					</ul>
 				</div>
 			</div>
 		</div>
 	</div>
-    
-    
-    
+
+
+
     <section id="a11" class="padding130 form_mt bg_blue2">
         <div class="container960">
             <p class="eng_midashi font2 white"><span>REQUEST FORM</span></p>
@@ -85,7 +85,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <p class="ta-c text22 mt-40 spmt-30 letter008 t-hi22 white">フォームに必要事項、ご相談内容をご記入ください。<br>
 担当者よりご返信いたします。</p>
 
-            
+
             <div id='crmWebToEntityForm' class='zcwf_lblLeft crmWebToEntityForm' style='background-color: white;color: black;'>
                 <form action='https://crm.zoho.com/crm/WebToLeadForm' name=WebToLeads5302731000000797027 method='POST' onSubmit='javascript:document.charset="UTF-8"; return checkMandatory5302731000000797027()' accept-charset='UTF-8'>
                     <input type='text' style='display:none;' name='xnQsjsdp' value='66c4db33fb74c6bb4296ef42797828ac52b4f03d84904a97232a335af6da9ede'>
@@ -240,17 +240,17 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 		  if(fieldObj) {
 			if (((fieldObj.value).replace(/^\s+|\s+$/g, '')).length==0) {
 			 if(fieldObj.type =='file')
-				{ 
-				 alert('アップロードするファイルを選択してください。'); 
-				 fieldObj.focus(); 
+				{
+				 alert('アップロードするファイルを選択してください。');
+				 fieldObj.focus();
 				 return false;
-				} 
-			alert(fldLangVal[i] +' は入力必須です。'); 
+				}
+			alert(fldLangVal[i] +' は入力必須です。');
    	   	  	  fieldObj.focus();
    	   	  	  return false;
 			}  else if(fieldObj.nodeName=='SELECT') {
   	   	   	 if(fieldObj.options[fieldObj.selectedIndex].value=='-None-') {
-				alert(fldLangVal[i] +' は入力必須です。'); 
+				alert(fldLangVal[i] +' は入力必須です。');
 				fieldObj.focus();
 				return false;
 			   }
@@ -259,8 +259,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 				alert('Please accept  '+fldLangVal[i]);
 				fieldObj.focus();
 				return false;
-			   } 
-			 } 
+			   }
+			 }
 			 try {
 			     if(fieldObj.name == 'Last Name') {
 				name = fieldObj.value;
@@ -285,7 +285,7 @@ function tooltipShow5302731000000797027(el){
 		tooltip.style.display='none';
 	}
 }
-</script> 
+</script>
         <!-- Do not remove this --- Analytics Tracking code starts --><script id='wf_anal' src='https://crm.zohopublic.com/crm/WebFormAnalyticsServeServlet?rid=5f0957e719dece60b4af3d8879616784323851bd2a15053e20470f2791326807gid66c4db33fb74c6bb4296ef42797828ac52b4f03d84904a97232a335af6da9edegid885e3c1045bd9bdcc91bdf30f82b5696gid14f4ec16431e0686150daa43f3210513&tw=61690b96c1d0471b638f31426f38e68aa67fb7ed6da86f32dc10ad817fe55a0a'></script><!-- Do not remove this --- Analytics Tracking code ends. -->
 
                 </form>
@@ -293,8 +293,8 @@ function tooltipShow5302731000000797027(el){
         </div>
     </section>
 
-            
-    
+
+
     <footer class="cy_footer">
         <div class="container1280">
             <div class="f_flex">
@@ -313,7 +313,7 @@ function tooltipShow5302731000000797027(el){
             <p class="copy">© SynCube Co., Ltd.</p>
         </div>
     </footer>
-    
+
 <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
 <script src="js/spmenu.js?ver1.3"></script>
 <script type="text/javascript" src="js/jsmin.js"></script>

--- a/synchroshift/request_thanks.html
+++ b/synchroshift/request_thanks.html
@@ -43,7 +43,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                             <li><a href="contact_form.html">お問い合わせ</a></li>
                         </ul>
                     </nav>
-                    <p class="h_contact"><a href="entry_form.html">無料で試す</a></p>
+                    <p class="h_contact"><a href="pre_entry_form.html">先行受付</a></p>
                 </div>
             </div>
         </div>
@@ -69,15 +69,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                         <li><a href="index.html#a10"><span class="font2">07.</span>料金プラン</a></li>
                         <li><a href="request_form.html"><span class="font2">08.</span>資料請求</a></li>
                         <li><a href="contact_form.html"><span class="font2">09.</span>お問い合わせ</a></li>
-                        <li><a href="entry_form.html"><span class="font2">10.</span>無料で試す</a></li>
+                        <li><a href="pre_entry_form.html"><span class="font2">10.</span>先行受付</a></li>
 					</ul>
 				</div>
 			</div>
 		</div>
 	</div>
-    
-    
-    
+
+
+
     <section id="a11" class="padding130 form_mt bg_blue2">
         <div class="container960 thanks_box">
             <div class="thanks_img"><img src="images/thanks.png" width="428" height="428" alt=""></div>
@@ -85,8 +85,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         </div>
     </section>
 
-            
-    
+
+
     <footer class="cy_footer">
         <div class="container1280">
             <div class="f_flex">
@@ -105,7 +105,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <p class="copy">© SynCube Co., Ltd.</p>
         </div>
     </footer>
-    
+
 <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
 <script src="js/spmenu.js?ver1.3"></script>
 <script type="text/javascript" src="js/jsmin.js"></script>

--- a/synchroshift/terms.html
+++ b/synchroshift/terms.html
@@ -43,7 +43,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                             <li><a href="contact_form.html">お問い合わせ</a></li>
                         </ul>
                     </nav>
-                    <p class="h_contact"><a href="entry_form.html">無料で試す</a></p>
+                    <p class="h_contact"><a href="pre_entry_form.html">先行受付</a></p>
                 </div>
             </div>
         </div>
@@ -69,15 +69,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                         <li><a href="index.html#a10"><span class="font2">07.</span>料金プラン</a></li>
                         <li><a href="request_form.html"><span class="font2">08.</span>資料請求</a></li>
                         <li><a href="contact_form.html"><span class="font2">09.</span>お問い合わせ</a></li>
-                        <li><a href="entry_form.html"><span class="font2">10.</span>無料で試す</a></li>
+                        <li><a href="pre_entry_form.html"><span class="font2">10.</span>先行受付</a></li>
 					</ul>
 				</div>
 			</div>
 		</div>
 	</div>
-    
-    
-    
+
+
+
     <section id="a11" class="padding130 form_mt">
         <div class="container1280">
             <p class="eng_midashi font2"><span>TERMS OF SERVICE</span></p>
@@ -86,10 +86,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <p class="mt-60 spmt-40">株式会社サインキューブ（以下「当社」といいます）は、当社の「シンクロシフト」の名称のもとに展開する各種クラウドサービス（以下あわせて「本サービス」といいます）の提供にあたり、以下のとおりサービス利用規約（以下「本規約」といいます）を定めます。本サービスの申込みにあたっては、本規約をよくお読みください。</p>
 
             <h3 class="midashi29 mt-120 indent_p12">第1章 総則</h3>
-            
+
             <h3 class="midashi22 mt-60 spmt-40">第1条 目的</h3>
             <p class="mt-30 spmt-20">本規約は、当社との間で本サービスの利用に関する契約（以下「サービス利用契約」といいます）を締結した者（以下「契約者」といいます）が、本サービスを利用するにあたって必要な条件を定めることを目的とします。</p>
-            
+
             <h3 class="midashi22 mt-35 spmt-30">第2条 定義</h3>
             <p class="mt-30 spmt-20">本規約では以下の用語を使用します。</p>
             <ul class="num_list2 mt-30 spmt-20">
@@ -105,7 +105,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 <li>10. 常勤換算表：事業所またはチーム単位で作成される勤務実績簿のことを意味します。</li>
                 <li>11. 知的財産権：著作権、特許権、実用新案権、意匠権、商標権その他一切の知的財産権（それらの権利を取得し、またはそれらの権利につき登録等を出願する権利を含みます。）を意味します。</li>
             </ul>
-            
+
             <h3 class="midashi22 mt-35 spmt-30">第3条 本規約の適用</h3>
             <ul class="num_list2 mt-30 spmt-20">
                 <li>1. 契約者は、本サービスの利用にあたり、本規約を遵守するものとします。</li>
@@ -113,22 +113,22 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 <li>3. 本サービスでは、ログイン後の機能として、事業所の登録・スタッフ登録、チームの登録、シフトの作成、常勤換算表の作成などを行うことができます。ただし、その全てが提供されることを保証するものではありません。</li>
                 <li>4. 本サービスの一部について、特定の利用プランの契約者に限り利用できるものがあります。また、契約者が利用することができる本サービスの内容、数量等は、利用プラン毎に異なります。詳細は、本サービスの WEBサイトをご確認ください。</li>
             </ul>
-            
+
             <h3 class="midashi22 mt-35 spmt-30">第4条 本規約等の変更</h3>
             <ul class="num_list2 mt-30 spmt-20">
                 <li>1. 当社は、必要な場合には、本規約を変更し又は本サービスの利用に関しガイドライン及び特約を定めること（以下これらをあわせて「本規約等の変更等」といいます）ができるものとします。</li>
                 <li>2. 当社は、本規約等の変更等を行う場合、当該変更等の効力発生前に、本規約等の変更等を行う旨、並びに当該本規約等の変更等の効力発生時期及び内容について、当社のウェブサイトへの掲載その他当社が適当と判断する方法により、契約者に周知するものとします。</li>
                 <li>3. 本規約等の変更等の効力発生時期が到来するまでに、当社が前項所定の周知を行った場合であって、契約者が本規約等の変更等の効力発生日以後に本サービスを利用した場合、当該契約者は、本規約等の変更等に同意したものとみなします</li>
             </ul>
-            
+
             <h3 class="midashi22 mt-35 spmt-30">第5条 通知</h3>
             <ul class="num_list2 mt-30 spmt-20">
                 <li>1. 当社は、本サービスに関連して契約者に通知をする場合には、当社のウェブサイトへの掲載、本サービスに登録された契約者の電子メールアドレスに宛てた電子メールの送信その他の当社が適当と判断する方法で実施するものとします。</li>
                 <li>2. 本サービスに登録された契約者の電子メールアドレス宛にメールを配信した際に、当該メールの配信が第29条第1項に定める届出が行われなかったことにより不着に終わった場合であっても、当社から契約者への通知は行われたものとみなし、この場合、当該メールアドレスへのメールの配信を停止することができるものとします。なお、当該当メールが受信できなかったこと又は配信を停止することにより、契約者に損害が生じたとしても、当社は一切の責任を負わないものとします。</li>
             </ul>
 
-            
-            
+
+
             <h3 class="midashi29 mt-120">第2章 サービス利用契約</h3>
 
             <h3 class="midashi22 mt-35 spmt-30">第6条 利用の申込み</h3>
@@ -174,8 +174,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 <li>14. アカウント削除後に再度契約される場合においてデータの復旧はできかねるためご注意ください。</li>
             </ul>
 
-            
-            
+
+
             <h3 class="midashi29 mt-120">第3章 本サービスの利用等</h3>
 
             <h3 class="midashi22 mt-35 spmt-30">第8条 本サービスの利用</h3>
@@ -244,8 +244,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 <li>5. 当社は、当社の管理外である通信回線や当社設備に属さない設備の状態について、一切の責任を負いません。</li>
             </ul>
 
-            
-            
+
+
             <h3 class="midashi29 mt-120">第4章 利用料金</h3>
 
             <h3 class="midashi22 mt-35 spmt-30">第14条 本サービスの利用料金</h3>
@@ -267,8 +267,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <p class="mt-30 spmt-20">契約者が、当社の指定する期日までに利用料金の支払をしなかった場合は、未払い額に遅延損害金を付して請求することがあります。<br>
 この場合の遅延損害金は、支払期日の翌日を起算日とし、年14.6％の日割計算で算出することとします。</p>
 
-            
-            
+
+
             <h3 class="midashi29 mt-120">第5章 情報の取り扱い</h3>
 
             <h3 class="midashi22 mt-35 spmt-30">第17条 秘密保持義務</h3>
@@ -297,8 +297,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 <li>4. 当社が本条に定める範囲で個人情報を利用しているにもかかわらず、当社が個人情報の保有当事者からクレーム、請求等を受けた場合、契約者は、自らの費用と責任でこれを解決するものとします。</li>
             </ul>
 
-            
-            
+
+
             <h3 class="midashi29 mt-120">第6章 本サービスの変更、中断、停止等</h3>
 
             <h3 class="midashi22 mt-35 spmt-30">第20条 本サービスの変更</h3>
@@ -358,8 +358,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <h3 class="midashi22 mt-35 spmt-30">第27条 契約終了時のデータについて</h3>
             <p class="mt-30 spmt-20">サービス利用契約を終了する場合、契約者は当社が指定する解約フォームから手続きを行うものとします。また半年間の利用がない場合に契約者の契約者データ等その他当社が契約者に提供した一切の情報を消去することができるものとします。契約者は、サービス利用契約の終了日までに自らの責任により必要な情報をダウンロードすることとし、当該終了日を経過した場合の情報の提供については応じないものとします。</p>
 
-            
-            
+
+
             <h3 class="midashi29 mt-120">第7章 その他</h3>
 
             <h3 class="midashi22 mt-35 spmt-30">第28条 譲渡・質入の禁止</h3>
@@ -424,8 +424,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         </div>
     </section>
 
-            
-    
+
+
     <footer class="cy_footer">
         <div class="container1280">
             <div class="f_flex">
@@ -444,7 +444,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             <p class="copy">© SynCube Co., Ltd.</p>
         </div>
     </footer>
-    
+
 <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
 <script src="js/spmenu.js?ver1.3"></script>
 <script type="text/javascript" src="js/jsmin.js"></script>


### PR DESCRIPTION
# 先行受付 に対応

## 変更点
- 「無料で試す」 -> 「先行受付」
- 「まずは無料でお試しください！」-> 「まずは先行受付にお申込みください！」
- 「※サービス正式リリース後の流れになります」を追加 ([詳細1](##詳細1)で説明)
- 下記ページを追加
	- 先行受付フォームページ
	- 先行受付サンクスページ
- Zoho Desk
	- 問い合わせに下記項目を追加
		- サービス種別
		- 事業所数
		- 役職
		- 従業員数
		- 所属組織
	- Webフォーム「シンクロシフト先行受付フォーム」を作成
		- 確認用にドメイン名に「*」を指定。リリース後に正しいものに変更する

## 詳細1
![image](https://github.com/syncuberepo/landingPage/assets/1967792/ee42f18c-b745-4df5-9bf0-54061a53801e)
「無料で試す」が画像になっていて修正が大変だと思ったので、「※サービス正式リリース後の流れになります」を追加しました。
この対応で良いのか、ここのフロー画像自体を非表示にするのか意見があればお願いします